### PR TITLE
Add compat with Ubuntu to simple_nokey scripts

### DIFF
--- a/ec2_simple_nokey/files/authorized_keys_command.sh
+++ b/ec2_simple_nokey/files/authorized_keys_command.sh
@@ -4,6 +4,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-aws iam list-ssh-public-keys --user-name "$1" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read KeyId; do
+aws iam list-ssh-public-keys --user-name "$1" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read KeyId
+do
   aws iam get-ssh-public-key --user-name "$1" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
 done

--- a/ec2_simple_nokey/files/import_users.sh
+++ b/ec2_simple_nokey/files/import_users.sh
@@ -4,7 +4,12 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
   if id -u "$User" >/dev/null 2>&1; then
     echo "$User exists"
   else
-    /usr/sbin/adduser "$User"
+    source /etc/os-release
+    if [ "$NAME" == "Ubuntu" ]; then
+      /usr/sbin/useradd -m "$User"
+    elif [ "$NAME" == "Amazon Linux AMI" ]; then
+      /usr/sbin/adduser "$User"
+    fi
     echo "$User ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$User"
   fi
 done

--- a/ec2_simple_nokey/files/import_users.sh
+++ b/ec2_simple_nokey/files/import_users.sh
@@ -6,7 +6,7 @@ aws iam list-users --query "Users[].[UserName]" --output text | while read User;
   else
     source /etc/os-release
     if [ "$NAME" == "Ubuntu" ]; then
-      /usr/sbin/useradd -m "$User"
+      /usr/sbin/useradd -m "$User" -s /bin/bash
     elif [ "$NAME" == "Amazon Linux AMI" ]; then
       /usr/sbin/adduser "$User"
     fi

--- a/ec2_simple_nokey/files/install.sh
+++ b/ec2_simple_nokey/files/install.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 
-# Install PIP to be able to install the AWS Cli (later used to get the ssh keys)
-#curl -O https://bootstrap.pypa.io/get-pip.py
-#sudo python27 get-pip.py
-#sudo /usr/local/bin/pip install awscli
-
-sudo yum update -y
-sudo yum install aws-cli -y
+# Install AWS Cli
+source /etc/os-release
+if [ "$NAME" == "Ubuntu" ]; then
+  ssh_service="ssh"
+  sudo apt-get update
+  sudo apt-get -y install python-pip
+  sudo pip install awscli
+elif [ "$NAME" == "Amazon Linux AMI" ]; then
+  ssh_service="sshd"
+  sudo yum update -y
+  sudo yum install aws-cli -y
+fi
 
 sudo cp authorized_keys_command.sh /opt/authorized_keys_command.sh
 sudo cp import_users.sh /opt/import_users.sh
 
-sudo sed -i 's:#AuthorizedKeysCommand none:AuthorizedKeysCommand /opt/authorized_keys_command.sh:g' /etc/ssh/sshd_config
-sudo sed -i 's:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g' /etc/ssh/sshd_config
+sudo echo -e "\nAuthorizedKeysCommand /opt/authorized_keys_command.sh" >> /etc/ssh/sshd_config
+sudo echo -e "\nAuthorizedKeysCommandUser nobody" >> /etc/ssh/sshd_config
 
 # Refresh users frequently
 sudo cp import_users.cron /etc/cron.d/import_users
@@ -21,4 +26,4 @@ sudo chmod 0644 /etc/cron.d/import_users
 # Run it immediately
 sudo /opt/import_users.sh
 
-sudo service sshd restart
+sudo service $ssh_service restart

--- a/ec2_simple_nokey/resources/instance_user_data.sh
+++ b/ec2_simple_nokey/resources/instance_user_data.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 # Install Git
-sudo yum install -y git
+source /etc/os-release
+if [ "$NAME" == "Ubuntu" ]; then
+  sudo apt-get -y install git
+elif [ "$NAME" == "Amazon Linux AMI" ]; then
+  sudo yum install -y git
+fi
 
 # Fetch setup files from Github over HTTPS. You can choose any other secure way to fetch your setup files
 cd /tmp


### PR DESCRIPTION
I have added some flags and updated commands to support the usage of the scripts with Ubuntu AMIs.

The terraform files are untouched. I have tested by setting `ami = "${data.aws_ami.ubuntu.id}"` in `ec2.tf` and adding the following in `variables.tf`.

```
data "aws_ami" "ubuntu" {
  most_recent = true
  filter {
    name = "name"
    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
  }
  filter {
    name = "virtualization-type"
    values = ["hvm"]
  }
  owners = ["099720109477"] # Canonical
}
```